### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,8 +143,62 @@ jobs:
           name: faf-uid-linux
           path: build/faf-uid
 
+  build-macos:
+    runs-on: macos-latest
+    environment: release
+    env:
+      PUB_KEY: ${{ secrets.UID_PUBLIC_KEY_PEM }}
+      JSONCPP_VERSION: 1.7.7
+      CRYPTOPP_VERSION: 8_9_0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write PUB key into file
+        run: echo "$PUB_KEY" > faf_pub.pem
+
+      - name: Build jsoncpp
+        run: |
+          wget https://github.com/open-source-parsers/jsoncpp/archive/$JSONCPP_VERSION.tar.gz -O jsoncpp.tar.gz
+          tar xfz jsoncpp.tar.gz
+          cmake \
+            -DCMAKE_BUILD_TYPE=MinSizeRel \
+            -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF \
+            -DBUILD_STATIC_LIBS=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -B jsoncpp-build \
+            -S jsoncpp-$JSONCPP_VERSION
+          make -C jsoncpp-build
+
+      - name: Build cryptopp
+        run: |
+          wget https://github.com/weidai11/cryptopp/archive/CRYPTOPP_$CRYPTOPP_VERSION.zip -O cryptopp.zip
+          unzip ./cryptopp.zip
+          mv cryptopp-CRYPTOPP_$CRYPTOPP_VERSION cryptopp
+          # cryptopp 8.9.0's GNUmakefile needs explicit arch/stdlib flags on
+          # Apple Silicon, its auto-detection is insufficient there.
+          make -C cryptopp -f GNUmakefile CXXFLAGS='-DNDEBUG -O3 -stdlib=libc++ -arch arm64' libcryptopp.a
+
+      - name: Build
+        run: |
+          cmake \
+            -DJSONCPP_LIBRARIES=$(pwd)/jsoncpp-build/src/lib_json/libjsoncpp.a \
+            -DJSONCPP_INCLUDE_DIRS=$(pwd)/jsoncpp-$JSONCPP_VERSION/include \
+            -DCRYPTOPP_LIBRARIES=$(pwd)/cryptopp/libcryptopp.a \
+            -DCRYPTOPP_INCLUDE_DIRS=$(pwd)/cryptopp \
+            -DCMAKE_BUILD_TYPE=MinSizeRel \
+            -DUID_PUBKEY_BYTES=$(./encode_openssl_modulus.py $(openssl rsa -noout -inform PEM -in faf_pub.pem -pubin -modulus)) \
+            -B build
+          make -C build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: faf-uid-macos
+          path: build/faf-uid
+
   create-release:
-    needs: [build-windows, build-linux]
+    needs: [build-windows, build-linux, build-macos]
     runs-on: ubuntu-latest
 
     steps:
@@ -160,6 +214,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: faf-uid-linux
+          path: release-artifacts/
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: faf-uid-macos
           path: release-artifacts/
 
       - name: Create release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,12 +190,15 @@ jobs:
             -DUID_PUBKEY_BYTES=$(./encode_openssl_modulus.py $(openssl rsa -noout -inform PEM -in faf_pub.pem -pubin -modulus)) \
             -B build
           make -C build
+          # Rename so this artifact's file doesn't collide with Linux's
+          # `faf-uid` when both are extracted into release-artifacts/.
+          mv build/faf-uid build/faf-uid-macos
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: faf-uid-macos
-          path: build/faf-uid
+          path: build/faf-uid-macos
 
   create-release:
     needs: [build-windows, build-linux, build-macos]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(faf-uid CXX C)
 
@@ -21,15 +21,17 @@ if(NOT DEFINED JSONCPP_LIBRARIES)
 endif()
 
 include_directories(${JSONCPP_INCLUDE_DIRS})
+link_directories(${JSONCPP_LIBRARY_DIRS})
 
 if(NOT DEFINED CRYPTOPP_LIBRARIES)
   if(NOT PKGCONFIG_FOUND)
     find_package(PkgConfig REQUIRED)
   endif()
-  pkg_search_module(CRYPTOPP REQUIRED cryptopp)
+  pkg_search_module(CRYPTOPP REQUIRED libcryptopp cryptopp)
 endif()
 
 include_directories(${CRYPTOPP_INCLUDE_DIRS})
+link_directories(${CRYPTOPP_LIBRARY_DIRS})
 
 if (WIN32)
   if(NOT PKGCONFIG_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ if (WIN32)
     ${ICU_LIBRARIES}
     wbemuuid.lib
       )
+elseif(APPLE)
+  set(machine_info_src machine_info_mac.cpp)
 else()
   set(machine_info_src machine_info_linux.cpp)
 endif()
@@ -61,7 +63,10 @@ if (WIN32)
   add_definitions(-DWIN32FAFUID)
 endif()
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+# macOS does not support fully-static linking
+if(NOT APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+endif()
 
 add_executable(faf-uid
   uid.cpp
@@ -83,10 +88,15 @@ target_link_libraries(faf-uid
   ${machine_info_libs}
   )
 
-# Strip exe to reduce file size
+# Strip exe to reduce file size (macOS strip does not accept -s)
+if(APPLE)
+  set(UID_STRIP_FLAGS)
+else()
+  set(UID_STRIP_FLAGS -s)
+endif()
 add_custom_command(TARGET faf-uid
   POST_BUILD
-  COMMAND ${CMAKE_STRIP} -s "$<TARGET_FILE:faf-uid>"
+  COMMAND ${CMAKE_STRIP} ${UID_STRIP_FLAGS} "$<TARGET_FILE:faf-uid>"
   COMMENT "Stripping executable $<TARGET_FILE_NAME:faf-uid>"
   )
 

--- a/machine_info_mac.cpp
+++ b/machine_info_mac.cpp
@@ -118,8 +118,13 @@ std::string machine_info_disks_controllerid()
 
 std::string machine_info_disks_vserial()
 {
+  // Anchor to the exact "UUID" key — ioreg output for IOMedia can
+  // include other keys containing the substring UUID (e.g.
+  // "VolGroupUUID", "Content Hint UUID"), and an unanchored /UUID/
+  // would match those first on any machine where they appear above
+  // the plain "UUID" line.
   return exec("ioreg -rd1 -c IOMedia "
-              "| awk '/UUID/ { gsub(/\"/, \"\", $3); print $3; exit }'");
+              "| awk '/\"UUID\" =/ { gsub(/\"/, \"\", $3); print $3; exit }'");
 }
 
 std::string machine_info_bios_manufacturer()
@@ -150,7 +155,13 @@ std::string machine_info_bios_date()
 
 std::string machine_info_bios_version()
 {
-  return exec("sysctl -n kern.osrelease");
+  // Apple Silicon has no BIOS; the equivalent is the BootROM /
+  // System Firmware Version. This is stable across macOS updates
+  // (only changes on firmware updates), so it gives a durable
+  // fingerprint contribution — unlike kern.osrelease, which changes
+  // with every OS point release.
+  return exec("system_profiler SPHardwareDataType "
+              "| awk -F': ' '/System Firmware Version/ {print $2; exit}'");
 }
 
 std::string machine_info_processor_name()

--- a/machine_info_mac.cpp
+++ b/machine_info_mac.cpp
@@ -1,0 +1,174 @@
+#include "machine_info.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <regex>
+#include <algorithm>
+#include <cctype>
+
+std::string exc_value("invalid");
+
+std::string& rtrim(std::string &s)
+{
+  s.erase(std::find_if(s.rbegin(),
+                       s.rend(),
+                       [](unsigned char ch) { return !std::isspace(ch); }).base(),
+          s.end());
+  return s;
+}
+
+std::string exec(const char* cmd)
+{
+  char buffer[128];
+  std::string result = "";
+  std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+  if (!pipe)
+  {
+    return exc_value;
+  }
+  while (!feof(pipe.get()))
+  {
+      if (fgets(buffer, 128, pipe.get()) != NULL)
+          result += buffer;
+  }
+  rtrim(result);
+  if (result.empty())
+  {
+    return exc_value;
+  }
+  return result;
+}
+
+std::string match_regex(std::string const& input,
+                        char const* r_string)
+{
+  std::regex r(r_string);
+  std::smatch sm;
+  if (std::regex_search(input, sm, r))
+  {
+    return sm[1];
+  }
+  return exc_value;
+}
+
+bool machine_info_init()
+{
+  return true;
+}
+
+bool machine_info_free()
+{
+  return false;
+}
+
+std::string machine_info_uuid()
+{
+  return exec("ioreg -rd1 -c IOPlatformExpertDevice "
+              "| awk '/IOPlatformUUID/ { gsub(/\"/, \"\", $3); print $3 }'");
+}
+
+std::string machine_info_model()
+{
+  return exec("sysctl -n hw.model");
+}
+
+std::string machine_info_manufacturer()
+{
+  return std::string("Apple Inc.");
+}
+
+// system_profiler SPDisplaysDataType can take several seconds; cache its
+// output so the width and height accessors share a single invocation.
+static std::string const& display_data()
+{
+  static std::string const data = exec("system_profiler SPDisplaysDataType");
+  return data;
+}
+
+std::string machine_info_display_width()
+{
+  return match_regex(display_data(), "Resolution:\\s+(\\d+)\\s+x\\s+\\d+");
+}
+
+std::string machine_info_display_height()
+{
+  return match_regex(display_data(), "Resolution:\\s+\\d+\\s+x\\s+(\\d+)");
+}
+
+std::string machine_info_memory_serial0()
+{
+  return exc_value;
+}
+
+std::string machine_info_motherboard_vendor()
+{
+  return std::string("Apple Inc.");
+}
+
+std::string machine_info_motherboard_name()
+{
+  return exec("sysctl -n hw.model");
+}
+
+std::string machine_info_disks_controllerid()
+{
+  return exc_value;
+}
+
+std::string machine_info_disks_vserial()
+{
+  return exec("ioreg -rd1 -c IOMedia "
+              "| awk '/UUID/ { gsub(/\"/, \"\", $3); print $3; exit }'");
+}
+
+std::string machine_info_bios_manufacturer()
+{
+  return std::string("Apple Inc.");
+}
+
+std::string machine_info_bios_smbbversion()
+{
+  return machine_info_bios_version();
+}
+
+std::string machine_info_bios_serial()
+{
+  return exec("ioreg -rd1 -c IOPlatformExpertDevice "
+              "| awk '/IOPlatformSerialNumber/ { gsub(/\"/, \"\", $3); print $3 }'");
+}
+
+std::string machine_info_bios_description()
+{
+  return exc_value;
+}
+
+std::string machine_info_bios_date()
+{
+  return exc_value;
+}
+
+std::string machine_info_bios_version()
+{
+  return exec("sysctl -n kern.osrelease");
+}
+
+std::string machine_info_processor_name()
+{
+  return exec("sysctl -n machdep.cpu.brand_string");
+}
+
+std::string machine_info_processor_id()
+{
+  return exc_value;
+}
+
+std::string machine_info_os_type()
+{
+  return exec("uname -s");
+}
+
+std::string machine_info_os_version()
+{
+  return exec("sw_vers -productVersion");
+}


### PR DESCRIPTION
  Adds native macOS build support to faf-uid.                                                                     
                                                                                                                  
  ## Changes                                                                                                      
                                                                                                                  
  - **`machine_info_mac.cpp`** — new implementation using `ioreg`, `sysctl`, and `system_profiler`. Follows the   
  style of `machine_info_linux.cpp` and returns `"invalid"` for fields Apple Silicon does not expose (memory      
  serial, disk controller id, bios date/description, processor id).                                               
                                                                                                                  
  - **`CMakeLists.txt`** — three edits:                                                                           
    - `elseif(APPLE)` selects `machine_info_mac.cpp`.                                                             
    - `-static` is skipped on macOS (Apple's linker does not support fully-static binaries).                      
    - Strip flag is platform-conditional (`strip -s` is a GNU extension; macOS `strip` rejects it).               
                                                                                                                  
  - **`.github/workflows/release.yaml`** — new `build-macos` job that mirrors `build-linux` on `macos-latest`     
  (Apple Silicon, arm64), using the same `jsoncpp` 1.7.7 and `cryptopp` 8.9.0 static-link pattern. Wired into     
  `create-release`'s `needs` list and download steps. Produces a `faf-uid-macos` artifact.                        
                                                                                                                  
  ## Companion PR                                                                                                 
                                                                                                                  
  Depends on FAForever/downlords-faf-client#3504 which adds macOS support in the client and consumes this     
  binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native macOS system information collection for more accurate device details.
  * macOS-specific utility binary included in releases (renamed for macOS).

* **Chores**
  * Added macOS build pipeline and integrated it into the release process so macOS artifacts are packaged automatically.
  * Adjusted build and post-build behavior to handle macOS-specific linking, architecture flags, and stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->